### PR TITLE
Add build instructions.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,16 @@
+*.o
+.deps/
+Makefile
+Makefile.in
+aclocal.m4
+autom4te.cache/
+config.guess
+config.log
+config.status
+config.sub
+configure
+depcomp
+install-sh
+missing
+ComPressure
+ComPressureServer

--- a/Makefile.am
+++ b/Makefile.am
@@ -33,8 +33,8 @@ ComPressure_SOURCES =  GameState.cpp GameState.h \
                     clip/clip.cpp clip/image.cpp $(EXTRA_SRC)
                     
 ComPressure_CXXFLAGS = @CXXFLAGS@ @SDL2_CFLAGS@ @SDL2_image_CFLAGS@ @SDL2_mixer_CFLAGS@ @SDL2_net_CFLAGS@ @SDL2_ttf_CFLAGS@ @ZLIB_CFLAGS@ @ZSTD_CFLAGS@ -I. $(STEAM_FLAGS)
-ComPressure_LDADD=@SDL2_LIBS@ @SDL2_image_LIBS@ @SDL2_mixer_LIBS@ @SDL2_net_LIBS@ @SDL2_ttf_LIBS@ @ZLIB_LIBS@ @ZSTD_LIBS@ $(STEAM_LDADD) $(EXTRA_LDADD)
-ComPressure_LDFLAGS=-L. -lpthread  $(EXTRA_LD_FLAGS)
+ComPressure_LDADD=@SDL2_LIBS@ @SDL2_image_LIBS@ @SDL2_mixer_LIBS@ @SDL2_net_LIBS@ @SDL2_ttf_LIBS@ @ZLIB_LIBS@ @ZSTD_LIBS@ $(STEAM_LDADD) $(EXTRA_LDADD) -lpthread
+ComPressure_LDFLAGS=-L. $(EXTRA_LD_FLAGS)
 
 ComPressureServer_SOURCES =  ComPressureServer.cpp \
                     Compress.cpp Compress.h \

--- a/README.TXT
+++ b/README.TXT
@@ -1,8 +1,0 @@
-Music by stephenpalmermail
-https://soundcloud.com/stephenpalmermail
-
-Graphic assets by Carl Olsson
-https://opengameart.org/users/surt
-
-Font by Poppy Works
-https://poppyworks.itch.io/silver

--- a/README.md
+++ b/README.md
@@ -1,0 +1,59 @@
+# Credits
+
+Music by stephenpalmermail
+https://soundcloud.com/stephenpalmermail
+
+Graphic assets by Carl Olsson
+https://opengameart.org/users/surt
+
+Font by Poppy Works
+https://poppyworks.itch.io/silver
+
+# Building
+
+Ensure you have checked out submodules e.g. via `git checkout
+--recurse-submodules` or `git submodule update --init` after checkout.
+
+Ensure you have all configuration setup, e.g. via `autoreconf` or manually via
+`aclocal`, `autoconf` and `automake`:
+
+```
+# initial checkout
+git checkout --recurse-submodules https://github.com/brejc8/ComPressure.git
+# or if not cloned with submodules run
+git submodule update --init
+
+# set up configuration files
+autoreconf --verbose --install
+# or manually via
+aclocal
+autoconf
+automake --add-missing
+
+# configure the build or see below for how to build with Steam support enabled
+./configure --disable-steam
+
+# build in parallel, or remove the flag
+make -j
+```
+
+If dependencies are missing, install them, preferably via the OS package
+management, e.g. on Ubuntu / Debian-based systems:
+
+```
+sudo apt-get install libsdl2-dev libsdl2-image-dev libsdl2-mixer-dev \
+  libsdl2-net-dev libsdl2-ttf-dev libxcb1-dev libzstd-dev zlib1g-dev
+```
+
+The [Steam SDK](https://partner.steamgames.com/downloads/steamworks_sdk.zip)
+has to be downloaded manually.  Due to authentication you'll have to do this in
+the browser and authenticate via Steam Guard.
+
+Unpack the downloaded file `steamworks_sdk.zip` and put it in a well-known
+location:
+
+```
+unzip -d <steam-sdk> steamworks_sdk.zip
+ln -s <steam-sdk>/sdk/public/steam .
+ln -s <steam-sdk>/sdk/redistributable_bin/linux64/libsteam_api.so .
+```


### PR DESCRIPTION
This adds some build instructions (for Linux only, I don't have access to other build configurations at this time).

Also includes a small fix for a build failure on my system due to the order of flags supplied to the linker:

```
g++   -L. -lpthread    -o ComPressure ComPressure-GameState.o ComPressure-main.o ComPressure-Misc.o ComPressure-SaveState.o ComPressure-Circuit.o ComPressure-Level.o ComPressure-Compress.o ComPressure-clip.o C
omPressure-image.o ComPressure-clip_x11.o  -lSDL2 -lSDL2_image -lSDL2 -lSDL2_mixer -lSDL2 -lSDL2_net -lSDL2 -lSDL2_ttf -lSDL2 -lz -lzstd -lsteam_api -lxcb
/usr/bin/ld: ComPressure-clip_x11.o: undefined reference to symbol 'pthread_create@@GLIBC_2.2.5'
/usr/bin/ld: /usr/lib/gcc/x86_64-linux-gnu/9/../../../x86_64-linux-gnu/libpthread.so: error adding symbols: DSO missing from command line
collect2: error: ld returned 1 exit status
make: *** [Makefile:492: ComPressure] Error 1
```