### PR TITLE
Slight optimization of FastSim

### DIFF
--- a/Circuit.cpp
+++ b/Circuit.cpp
@@ -231,56 +231,6 @@ XYPos CircuitElementPipe::getimage(void)
     return XYPos((connections % 4) * 32, (connections / 4) * 32);
 }
 
-static void sim_pre_2links(CircuitPressure& a, CircuitPressure& b)
-{
-    Pressure mov = (a.value - b.value) / 2;
-    a.move(-mov);
-    b.move(mov);
-}
-
-
-static void sim_pre_3links(CircuitPressure& a, CircuitPressure& b, CircuitPressure& c)
-{
-    Pressure mov = (a.value - b.value) / 3;
-    a.move(-mov);
-    b.move(mov);
-
-    mov = (a.value - c.value) / 3;
-    a.move(-mov);
-    c.move(mov);
-
-    mov = (b.value - c.value) / 3;
-    b.move(-mov);
-    c.move(mov);
-}
-
-static void sim_pre_4links(CircuitPressure& a, CircuitPressure& b, CircuitPressure& c, CircuitPressure& d)
-{
-    Pressure mov = (a.value - b.value) / 4;
-    a.move(-mov);
-    b.move(mov);
-
-    mov = (a.value - c.value) / 4;
-    a.move(-mov);
-    c.move(mov);
-
-    mov = (b.value - c.value) / 4;
-    b.move(-mov);
-    c.move(mov);
-
-    mov = (a.value - d.value) / 4;
-    a.move(-mov);
-    d.move(mov);
-
-    mov = (b.value - d.value) / 4;
-    b.move(-mov);
-    d.move(mov);
-
-    mov = (c.value - d.value) / 4;
-    c.move(-mov);
-    d.move(mov);
-}
-
 void CircuitElementPipe::extend_pipe(Connections con)
 {
     if (connections == CONNECTIONS_NONE) connections = con;
@@ -511,7 +461,7 @@ void CircuitElementValve::sim(PressureAdjacent adj)
     if (mul < 0)
         mul = 0;
 
-                                                            // base resistence is 8 pipes
+    // base resistence is 8 pipes
     Pressure mov = (int64_t(adj.W.value - adj.E.value) * mul) / (int64_t(100) * 2 * resistence * PRESSURE_SCALAR);
     adj.W.move(-mov);
     adj.E.move(mov);

--- a/Circuit.h
+++ b/Circuit.h
@@ -192,17 +192,10 @@ class FastSim
         {}
         void sim()
         {
-            Pressure mov = (a.value - b.value) / 3;
-            a.move(-mov);
-            b.move(mov);
-
-            mov = (a.value - c.value) / 3;
-            a.move(-mov);
-            c.move(mov);
-
-            mov = (b.value - c.value) / 3;
-            b.move(-mov);
-            c.move(mov);
+            Pressure all = (a.value + b.value + c.value) / 3;
+            a.move(all - a.value);
+            b.move(all - b.value);
+            c.move(all - c.value);
         }
     };
 
@@ -221,29 +214,11 @@ class FastSim
         {}
         void sim()
         {
-            Pressure mov = (a.value - b.value) / 4;
-            a.move(-mov);
-            b.move(mov);
-
-            mov = (a.value - c.value) / 4;
-            a.move(-mov);
-            c.move(mov);
-
-            mov = (b.value - c.value) / 4;
-            b.move(-mov);
-            c.move(mov);
-
-            mov = (a.value - d.value) / 4;
-            a.move(-mov);
-            d.move(mov);
-
-            mov = (b.value - d.value) / 4;
-            b.move(-mov);
-            d.move(mov);
-
-            mov = (c.value - d.value) / 4;
-            c.move(-mov);
-            d.move(mov);
+            Pressure all = (a.value + b.value + c.value + d.value) / 4;
+            a.move(all - a.value);
+            b.move(all - b.value);
+            c.move(all - c.value);
+            d.move(all - d.value);
         }
     };
 
@@ -420,8 +395,8 @@ public:
 
 class CircuitElementValve : public CircuitElement
 {
-    const int resistence = 8;
-
+    // Make it constexpr so that compiler can optimize away division in sim.
+    static constexpr int resistence = 8;
     Pressure pressure = 0;
     int openness = 0;
     int moved_pos = 0;


### PR DESCRIPTION
Changed `CircuitElementValue::pressure` to be a `static constexpr`, which makes the divisor compile time constant in the division in `CircuitElementValve::sim`, allowing the compiler to turn it into a multiplication followed by right shift. This should be bit-for-bit equivalent to the original code, assuming the dividend fits in 32 bits.

Rearranged the expressions in FastSimPipe3 and FastSimPipe4. If you take the sum of the arguments to `a.move`, a pattern emerges:
```
a_delta = -(a-b)/3 -(a-c)/3
        = (-a+b-a+c)/3
        = (-2a+b+c)/3
        = (a+b+c - 3a)/3
        = (a+b+c)/3 - a
```
This generalizes to `(a+b+c+...)/n - a` for all ports in a n-way valve.
I also removed the unused `sim_pre_Xlinks` functions.

I benchmarked the code before and after by setting the speed slider to max and letting it settle Latch5 and Latch10. I get the following simticks per second (eyeballing for the most common value), an 11% improvement:
```
        Before After
Latch5  51000  57000
Latch10 19700  22000
```